### PR TITLE
Cargo.lock: Remove [root] section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,9 @@
-[root]
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rls-span"
 version = "0.4.0"
 dependencies = [
@@ -6,11 +11,6 @@ dependencies = [
  "serde 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"


### PR DESCRIPTION
Support for reading rootless lock files was added in cargo PR 3031,
which landed in cargo 0.14, released in November of 2016.  Cargo stopped
generating the root section in cargo PR 4571, which landed in cargo
0.23.

refs https://github.com/rust-lang/cargo/pull/3031
refs https://github.com/rust-lang/cargo/issues/4563
refs https://github.com/rust-lang/cargo/pull/4571